### PR TITLE
Fix router socket handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+bin/*

--- a/src/ipython_clojure/core.clj
+++ b/src/ipython_clojure/core.clj
@@ -60,10 +60,12 @@
         content  (cheshire/generate-string kernel-info-content)]
 
     ;; First send the client identifiers for the router socket's benefit
-    (doseq [ident (:idents message)]
-      (zmq/send socket ident zmq/send-more))
-    (zmq/send socket (byte-array 0) zmq/send-more)
+    (when (not (empty? (:idents message)))
+      (doseq [ident (:idents message)]
+        (zmq/send socket ident zmq/send-more))
+      (zmq/send socket (byte-array 0) zmq/send-more))
 
+    (send-message-piece socket (get-in message [:header :session]))
     (send-message-piece socket "<IDS|MSG>")
     (send-message-piece socket (signer header parent_header metadata content))
     (send-message-piece socket header)
@@ -78,10 +80,12 @@
         content  (cheshire/generate-string kernel-info-content)]
 
     ;; First send the client identifiers for the router socket's benefit
-    (doseq [ident (:idents message)]
-      (zmq/send socket ident zmq/send-more))
-    (zmq/send socket (byte-array 0) zmq/send-more)
+    (when (not (empty? (:idents message)))
+      (doseq [ident (:idents message)]
+        (zmq/send socket ident zmq/send-more))
+      (zmq/send socket (byte-array 0) zmq/send-more))
 
+    (send-message-piece socket (get-in message [:header :session]))
     (send-message-piece socket "<IDS|MSG>")
     (send-message-piece socket (signer header parent_header metadata content))
     (send-message-piece socket header)
@@ -145,10 +149,12 @@
         metadata (cheshire/generate-string metadata)
         content (cheshire/generate-string content)]
 
-    (doseq [ident idents] ; First send the zmq identifiers for the router socket's benefit
-      (zmq/send socket ident zmq/send-more))
-    (zmq/send socket (byte-array 0) zmq/send-more)
+    (when (not (empty? idents))
+      (doseq [ident idents] ; First send the zmq identifiers for the router socket's benefit
+        (zmq/send socket ident zmq/send-more))
+      (zmq/send socket (byte-array 0) zmq/send-more))
 
+    (send-message-piece socket session-id)
     (send-message-piece socket "<IDS|MSG>")
     (send-message-piece socket (signer header parent_header metadata content))
     (send-message-piece socket header)


### PR DESCRIPTION
Clojupyter was not correctly handling the shell socket, which is a ZMQ router socket. With router sockets, you have to read and send back the ZMQ identifiers. For some weird reason the code was sending back the IPython session ID instead of these identifiers. As a result, ZMQ was silently dropping any responses on the shell socket so the frontend never saw them. This PR fixes this problem and also makes Clojupyter gracefully handle an empty key.