### PR TITLE
Makefile Standardization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 all:
-	mkdir -p ~/.ipython/kernels/clojure
-	rm -f target/*.jar
 	lein uberjar
-	cat bin/ipython-clojure.template target/*-standalone.jar > bin/ipython-clojure
+	cat bin/ipython-clojure.template $$(find . -maxdepth 2 -type f | grep -e ".*standalone.*\.jar") > bin/ipython-clojure
 	chmod +x bin/ipython-clojure
+
+clean:
+	rm -f *.jar
+	rm -f target/*.jar
+
+install:
+	mkdir -p ~/.ipython/kernels/clojure
 	cp bin/ipython-clojure ~/.ipython/kernels/clojure/ipython-clojure
 	@if [ ! -f ~/.ipython/kernels/clojure/kernel.json ]; then\
 		sed 's|HOME|'${HOME}'|' resources/kernel.json > ~/.ipython/kernels/clojure/kernel.json;\

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ IPython console and notebook.
 1. git clone https://github.com/roryk/clojupyter
 2. cd clojupyter
 3. make
+4. make install
 
 This will install a clojupyter executable and a configuration file to tell
 Jupyter how to use it in ~/.ipython/kernels/clojure.


### PR DESCRIPTION
Instead of having `make` take care of installation as well as the initial project build, this new Makefile is separated into two major parts for installation

1. Project build
2. Kernel installation

Each operation is side-effect free and disjoint from the other operations. This method of separation is somewhat standard among projects that need to be built, and it would be good to keep with that. Anyone initially downloading the project will expect this separation.