### PR TITLE
Avoid exceptions when return value is a list

### DIFF
--- a/src/ipython_clojure/core.clj
+++ b/src/ipython_clojure/core.clj
@@ -202,7 +202,7 @@
         (try
           (let [s# (new java.io.StringWriter) [output results]
               (binding [*out* s#]
-                (let [result (pr-str (eval (load-string
+                (let [result (pr-str (eval (read-string
                                             (get-in message [:content :code]))))
                       output (str s#)]
                   [output, result]))]


### PR DESCRIPTION
This prevents exceptions where lists get interpreted incorrectly as expressions.

Before:
![screen shot 2015-11-20 at 10 03 17 am](https://cloud.githubusercontent.com/assets/35297/11306523/9fadbbe8-8f6f-11e5-98dd-551e7ee6ae2a.png)

After:
![screen shot 2015-11-20 at 10 16 52 am](https://cloud.githubusercontent.com/assets/35297/11306551/d8a30674-8f6f-11e5-8d71-ca58afa37ab1.png)

