### PR TITLE
use nrepl, not eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ jupyter-notebook
 
 and select the Clojure kernel.
 
-### status
-Should work for simple stuff in the REPL. Doesn't handle errors or any type
-of complex data from Clojure. Also does not handle changing namespaces. We'd really like help with this.
+### Status
+Works. See the 'to do' list below, however.
 
-### collaboration
+###To Do:
+ * Shut down cleanly.
+ * Do syntax checking. It currently returns nil on unbalanced form. Borrow cider-nrepl middleware for this.
+ * Allow controls from Jupyter, including timeout and what classes of stack frames to show.
+ * Test (implement?) interrupt handling. Default middleware for interruptible-eval is loaded. 
+ * Implement file load. Use cider-nrepl middleware.
+
+### Collaboration
 If you submit a pull request that ends up getting merged, we will give you commit access.

--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,17 @@
   :description "An IPython kernel for executing Clojure code"
   :url "http://github.com/roryk/ipython-clojure"
   :license {:name "MIT"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.zeromq/jeromq "0.3.3"]
-                 [cheshire "5.3.1"]
-                 [clj-time "0.7.0"]
-                 [pandect "0.5.3"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.zeromq/jeromq "0.3.4"] ; "0.3.5" (modern) fails on zmq/bind.
+                 [cheshire "5.5.0"]
+                 [clj-time "0.11.0"]
+                 [pandect "0.5.4"]
                  [org.zeromq/cljzmq "0.1.4" :exclusions [org.zeromq/jzmq]]
-                 [org.clojure/data.json "0.2.4"]]
+                 [org.clojure/data.json "0.2.6"]
+                 [com.cemerick/pomegranate "0.3.0"]
+                 [mvxcvi/puget "1.0.0"]
+                 [fipp "0.6.4"]
+                 [org.clojure/tools.nrepl "0.2.12"]]
   :aot [ipython-clojure.core]
   :main ipython-clojure.core
   :jvm-opts ["-Xmx250m"]

--- a/resources/connect.json
+++ b/resources/connect.json
@@ -1,0 +1,11 @@
+{
+  "transport": "tcp",
+  "signature_scheme": "hmac-sha256",
+  "iopub_port": 45457,
+  "key": "a64cb910-8962-4d76-851a-3a08bac0c6a4",
+  "ip": "127.0.0.1",
+  "stdin_port": 41173,
+  "shell_port": 38108,
+  "hb_port": 42197,
+  "control_port": 58058
+}

--- a/src/ipython_clojure/core.clj
+++ b/src/ipython_clojure/core.clj
@@ -1,46 +1,35 @@
 (ns ipython-clojure.core
-  (:require [clojure.data.json :as json]
+  (:require 
+            [ipython-clojure.middleware.pprint]
+            [ipython-clojure.middleware.stacktrace]
+            [clojure.data.json :as json]
+            [clojure.java.io :as io]
             [cheshire.core :as cheshire]
             [clojure.walk :as walk]
             [zeromq.zmq :as zmq]
             [clj-time.core :as time]
             [clj-time.format :as time-format]
-            [pandect.algo.sha256 :refer [sha256-hmac]])
-  (:import [org.zeromq ZMQ])
+            [pandect.algo.sha256 :refer [sha256-hmac]]
+            [clojure.tools.nrepl :as repl]
+            [clojure.tools.nrepl.server :as nrepl-server])
+  (:import [org.zeromq ZMQ]
+           [java.net ServerSocket])
   (:gen-class :main true))
 
 (def protocol-version "5.0")
 
-(defmacro try-let
-  "A combination of try and let such that exceptions thrown in the binding or
-   body can be handled by catch clauses in the body, and all bindings are
-   available to the catch and finally clauses. If an exception is thrown while
-   evaluating a binding value, it and all subsequent binding values will be nil.
-   Example:
-   (try-let [x (f a)
-             y (f b)]
-     (g x y)
-     (catch Exception e (println a b x y e)))"
-  {:arglists '([[bindings*] exprs* catch-clauses* finally-clause?])}
-  [bindings & exprs]
-  (when-not (even? (count bindings))
-    (throw (IllegalArgumentException. "try-let requires an even number of forms in binding vector")))
-  (let [names  (take-nth 2 bindings)
-        values (take-nth 2 (next bindings))
-        ex     (gensym "ex__")]
-    `(let [~ex nil
-           ~@(interleave names (repeat nil))
-           ~@(interleave
-               (map vector names (repeat ex))
-               (for [v values]
-                 `(if ~ex
-                    [nil ~ex]
-                    (try [~v nil]
-                      (catch Throwable ~ex [nil ~ex])))))]
-      (try
-        (when ~ex (throw ~ex))
-        ~@exprs))))
+;;; Map of sockets used; useful for debug shutdown
+(defonce jup-sockets  (atom {}))
 
+(defn get-free-port! 
+  "Get a free port. Problem?: might be taken before I use it."
+  []
+  (let [socket (ServerSocket. 0)
+        port (.getLocalPort socket)]
+    (.close socket)
+    port))
+
+(def the-nrepl (atom nil))
 
 (defn prep-config [args]
   (-> args first slurp json/read-str walk/keywordize-keys))
@@ -52,7 +41,7 @@
 
 (def kernel-info-content
   {:protocol_version protocol-version
-   :language_version "1.5.1"
+   :language_version "1.8"
    :language "clojure"})
 
 (defn now []
@@ -176,7 +165,6 @@
         parent_header (cheshire/generate-string parent_header)
         metadata (cheshire/generate-string metadata)
         content (cheshire/generate-string content)]
-
     (when (not (empty? idents))
       (doseq [ident idents] ; First send the zmq identifiers for the router socket's benefit
         (zmq/send socket ident zmq/send-more))
@@ -230,7 +218,58 @@
                     (pyin-content @execution-count message)
                     parent-header {} session-id signer))))
 
-(defn execute-request-handler [shell-socket iopub-socket executer]
+(def nrepl-session (atom nil))
+
+(defn set-session! 
+  "All interaction will occur in one session; this sets atom nrepl-session to it."
+  []
+  (reset! nrepl-session
+          (with-open [conn (repl/connect :port (:port @the-nrepl))]
+            (-> (repl/client conn 10000) 
+                (repl/message {:op :clone})
+                doall
+                repl/combine-responses
+                :new-session))))
+
+(defn request-trace
+  "Request a stacktrace for the most recent exception."
+  [transport]
+  (-> (repl/client transport 10000)
+      (repl/message {:op "stacktrace" :session @nrepl-session})
+      repl/combine-responses
+      doall))
+
+(defn stacktrace-string
+  "Return a nicely formatted string."
+  [msg]
+  (when-let [st (:stacktrace msg)]
+    (let [clean (->> st
+                     (filter (fn [f] (not-any? #(= "dup" %) (:flags f))))
+                     (filter (fn [f] (not-any? #(= "tooling" %) (:flags f))))
+                     (filter (fn [f] (not-any? #(= "repl" %) (:flags f))))
+                     (filter :file))
+          max-file (apply max (map count (map :file clean)))
+          max-name (apply max (map count (map :name clean)))]
+      (str (format "%s (%s)\n\n" (:message msg) (:class msg))
+           (apply str
+                  (map #(format (str "%" max-file "s: %5d %-" max-name "s  \n") 
+                                (:file %) (:line %) (:name %)) 
+
+                       clean))))))
+
+(defn nrepl-eval
+  "Send message to nrepl and process response."
+  [code transport] 
+  (let [result (-> (repl/client transport 3000) ; timeout=3sec. 
+                   (repl/message {:op :eval :session @nrepl-session :code code})
+                   repl/combine-responses)]
+    (cond (empty? result) "Clojure: Unbalanced parentheses or kernel timed-out while processing form.", 
+          (seq (:ex result)) (stacktrace-string (request-trace transport))
+          :else (if-let [vals (:value result)]
+                  (apply str (interpose " " vals)) ; could have sent multiple forms
+                  "Unexpected response from Clojure."))))
+
+(defn execute-request-handler [shell-socket iopub-socket transport]
   (let [execution-count (atom 0N)
         busy-handler (get-busy-handler iopub-socket)]
     (fn [message signer]
@@ -238,82 +277,33 @@
             parent-header (:header message)]
         (swap! execution-count inc)
         (busy-handler message signer execution-count)
-        (try
-          (let [s# (new java.io.StringWriter) [output results]
-                (binding [*out* s#]
-                  (let [result (pr-str (eval (read-string
-                                              (get-in message [:content :code]))))
+        (let [s# (new java.io.StringWriter) 
+              [output result] 
+              (binding [*out* s#]
+                (let [result (nrepl-eval (get-in message [:content :code]) transport)
                       output (str s#)]
                   [output, result]))]
-            (send-router-message shell-socket "execute_reply"
-                                 {:status "ok"
-                                  :execution_count @execution-count
-                                  :user_expressions {}}
-                                 parent-header
-                                 {:dependencies_met "True"
-                                  :engine session-id
-                                  :status "ok"
-                                  :started (now)} session-id signer (:idents message))
-            ;; Send stdout
-            (send-message iopub-socket "stream" {:name "stdout" :text output}
-                          parent-header {} session-id signer)
-            ;; Send results
-            (send-message iopub-socket "execute_result"
-                          {:execution_count @execution-count
-                           :data {:text/plain results}
-                           :metadata {}
-                           }
-                          parent-header {} session-id signer))
-          (catch Exception e
-            ;; Send error on iopub socket
-            (send-message iopub-socket "error"
-                          {:execution_count @execution-count
-                           :ename (.getSimpleName (.getClass e))
-                           :evalue (.getLocalizedMessage e)
-                           :traceback (map #(.toString %) (.getStackTrace e))
-                           }
-                          parent-header {} session-id signer)
-            ;; Send an error execute_reply message
-            (send-router-message shell-socket "execute_reply"
-                                 {:status "error"
-                                  :execution_count @execution-count
-                                  :ename (.getSimpleName (.getClass e))
-                                  :evalue (.getLocalizedMessage e)
-                                  :traceback (map #(.toString %) (.getStackTrace e))
-                                  }
-                                 parent-header
-                                 {:dependencies_met "True"
-                                  :engine session-id
-                                  :status "ok"
-                                  :started (now)} session-id signer (:idents message)))
-          )
+          (send-router-message shell-socket "execute_reply"
+                               {:status "ok"
+                                :execution_count @execution-count
+                                :user_expressions {}}
+                               parent-header
+                               {:dependencies_met "True"
+                                :engine session-id
+                                :status "ok"
+                                :started (now)} session-id signer (:idents message))
+          ;; Send stdout
+          (send-message iopub-socket "stream" {:name "stdout" :text output}
+                        parent-header {} session-id signer)
+          ;; Send result
+          (send-message iopub-socket "execute_result"
+                        {:execution_count @execution-count
+                         :data {:text/plain result}
+                         :metadata {}
+                         }
+                        parent-header {} session-id signer))
         (send-message iopub-socket "status" (status-content "idle")
                       parent-header {} session-id signer)))))
-
-(defn execute
-  "evaluates s-forms"
-  ([request] (execute request *ns*))
-  ([request user-ns]
-    (str
-      (try
-        (binding [*ns* user-ns] (eval (read-string request)))
-        (catch Exception e (.getLocalizedMessage e))))))
-
-(defn generate-ns []
-  "generates ns for client connection"
-  (let [user-ns (create-ns (gensym "client-"))]
-    (execute (str "(clojure.core/refer 'clojure.core)") user-ns)
-    user-ns))
-
-
-(defn get-executer []
-  "evaluates s-forms"
-  (let [user-ns (generate-ns)]
-    (fn [request]
-      (str
-       (try
-         (binding [*ns* user-ns] (eval (read-string request)))
-         (catch Exception e (.getLocalizedMessage e)))))))
 
 (defn history-reply [message signer]
   "returns REPL history, not implemented for now and returns a dummy message"
@@ -322,9 +312,14 @@
 (defn shutdown-reply [message signer]
   {:restart true})
 
-(defn configure-shell-handler [shell-socket iopub-socket signer]
-  (let [execute-request (execute-request-handler shell-socket iopub-socket
-                                                 (get-executer))]
+(defn is-complete-reply
+  "Returns whether or not what the user has typed is complete (ready for execution).
+   Not yet implemented. May be  that it is just used by jupyter-console."
+  [message signer]
+  true)
+
+(defn configure-shell-handler [shell-socket iopub-socket signer nrepl-transport]
+  (let [execute-request (execute-request-handler shell-socket iopub-socket nrepl-transport)]
     (fn [message]
       (let [msg-type (get-in message [:header :msg_type])]
         (case msg-type
@@ -333,6 +328,7 @@
           "history_request" (history-reply message signer)
           "shutdown_request" (shutdown-reply message signer)
           "comm_open" (immediately-close-comm message shell-socket signer)
+          "is_complete_request" (is-complete-reply message signer)
           (do
             (println "Message type" msg-type "not handled yet. Exiting.")
             (println "Message dump:" message)
@@ -342,24 +338,47 @@
     Runnable
     (run [this]
       (let [context (zmq/context 1)
-            socket (doto (zmq/socket context :rep)
+            socket (doto (:hb (swap! jup-sockets assoc :hb (zmq/socket context :rep)))
                      (zmq/bind addr))]
         (while (not (.. Thread currentThread isInterrupted))
           (let [message (zmq/receive socket)]
             (zmq/send socket message))))))
 
+(def clojupyter-middleware
+  "A vector containing all Clojupyters middleware (additions to nrepl default)."
+  '[ipython-clojure.middleware.pprint/wrap-pprint
+    ipython-clojure.middleware.pprint/wrap-pprint-fn
+    ipython-clojure.middleware.stacktrace/wrap-stacktrace])
+
+(def clojupyer-nrepl-handler
+  "Clojupyters nREPL handler."
+  (apply nrepl-server/default-handler (map resolve clojupyter-middleware)))
+
+(defn start-nrepl 
+  "Start an nrepl server. Stop the existing one, if any (only possible when debugging)."
+  []
+  (when-let [server @the-nrepl]
+    (nrepl-server/stop-server server))
+  (reset! the-nrepl
+          (nrepl-server/start-server 
+           :port (get-free-port!)
+           :handler clojupyer-nrepl-handler))
+  (set-session!))
+
 (defn shell-loop [shell-addr iopub-addr signer checker]
-  (let [context (zmq/context 1)
-        shell-socket (doto (zmq/socket context :router)
-                       (zmq/bind shell-addr))
-        iopub-socket (doto (zmq/socket context :pub)
-                       (zmq/bind iopub-addr))
-        shell-handler (configure-shell-handler shell-socket iopub-socket signer)]
+  (start-nrepl)
+  (with-open [transport (repl/connect :port (:port @the-nrepl))]
+    (let [context (zmq/context 1)
+          shell-socket (doto (:sh (swap! jup-sockets assoc :sh (zmq/socket context :router)))
+                         (zmq/bind shell-addr))
+          iopub-socket (doto (:io (swap! jup-sockets assoc :io (zmq/socket context :pub)))
+                         (zmq/bind iopub-addr))
+          shell-handler (configure-shell-handler shell-socket iopub-socket signer transport)]
 
     (while (not (.. Thread currentThread isInterrupted))
       (let [message (read-raw-message shell-socket)
             parsed-message (parse-message message)]
-        (shell-handler parsed-message)))))
+        (shell-handler parsed-message))))))
 
 (defn -main [& args]
   (let [hb-addr (address (prep-config args) :hb_port)

--- a/src/ipython_clojure/middleware/pprint.clj
+++ b/src/ipython_clojure/middleware/pprint.clj
@@ -1,0 +1,125 @@
+(ns ipython-clojure.middleware.pprint
+  (:require [clojure.pprint :refer [pprint *print-right-margin*]]
+            [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
+            [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.middleware.session :as session]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as transport]
+            [fipp.edn :as fipp]
+            [puget.printer :as puget])
+  (:import clojure.tools.nrepl.transport.Transport))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Modified from cider-nrepl/src/cider/nrepl/middleware/pprint.clj
+
+(defn as-sym
+  [x]
+  (cond
+    (symbol? x) x
+    (string? x) (if-let [[_ ns sym] (re-matches #"(.+)/(.+)" x)]
+                  (symbol ns sym)
+                  (symbol x))))
+
+(defn fipp-pprint [object]
+  (fipp/pprint object {:width (or *print-right-margin* 72)}))
+
+(defn puget-pprint [object]
+  (puget/pprint object {:width (or *print-right-margin* 72)
+                        :seq-limit *print-length*}))
+
+(defn- resolve-pprint-fn
+  [sym]
+  (let [var (some-> sym as-sym resolve)]
+
+    (when (or (nil? var) (not (var? var)))
+      (throw (IllegalArgumentException. (format "%s is not resolvable as a var" sym))))
+
+    @var))
+
+(defn wrap-pprint-fn
+  "Middleware that provides a common interface for other middlewares that need
+  to perform customisable pretty-printing.
+
+  A namespace-qualified name of the function to be used for printing can be
+  optionally passed in the `:pprint-fn` slot, the default value being
+  `clojure.pprint/pprint`.
+
+  The `:pprint-fn` slot will be replaced with a closure that calls the given
+  printing function with `*print-length*`, `*print-level*`, `*print-meta*`, and
+  `clojure.pprint/*print-right-margin*` bound to the values of the
+  `:print-length`, `:print-level`, `:print-meta`, and `:print-right-margin`
+  slots respectively.
+
+  Middlewares further down the stack can then look up the `:pprint-fn` slot and
+  call it where necessary."
+  [handler]
+  (fn [{:keys [pprint-fn print-length print-level print-meta print-right-margin session]
+        :or {pprint-fn 'clojure.pprint/pprint}
+        :as msg}]
+    (handler (assoc msg :pprint-fn (fn [object]
+                                     (binding [*print-length* (or print-length (get @session #'*print-length*))
+                                               *print-level* (or print-level (get @session #'*print-level*))
+                                               *print-meta* (or print-meta (get @session #'*print-meta*))
+                                               *print-right-margin* (or print-right-margin (get @session #'*print-right-margin*))]
+                                       ((resolve-pprint-fn pprint-fn) object)))))))
+
+(def wrap-pprint-fn-optional-arguments
+  {"pprint-fn" "The namespace-qualified name of a single-arity function to use for pretty-printing. Defaults to `clojure.pprint/pprint`."
+   "print-length" "Value to bind to `*print-length*` when pretty-printing. Defaults to the value bound in the current REPL session."
+   "print-level" "Value to bind to `*print-level*` when pretty-printing. Defaults to the value bound in the current REPL session."
+   "print-meta" "Value to bind to `*print-meta*` when pretty-printing. Defaults to the value bound in the current REPL session."
+   "print-right-margin" "Value to bind to `clojure.pprint/*print-right-margin*` when pretty-printing. Defaults to the value bound in the current REPL session."})
+
+(set-descriptor!
+ #'wrap-pprint-fn
+ {:requires #{#'session/session}})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- pprint-writer
+  [{:keys [session transport] :as msg}]
+  (#'session/session-out :pprint-out (:id (meta session)) transport))
+
+(defn pprint-reply
+  [{:keys [pprint-fn session transport] :as msg} response]
+  (with-open [writer (pprint-writer msg)]
+    ;; Binding `*msg*` sets the `:id` slot when printing to an nREPL session
+    ;; PrintWriter (as created by `pprint-writer`), which the client requires to
+    ;; handle the response correctly.
+    (binding [*msg* msg *out* writer]
+      (let [value (:value response) 
+            print-fn (if (string? value) println pprint-fn)]
+        (print-fn value))))
+  (transport/send transport (response-for msg :pprint-sentinel {})))
+
+(defn pprint-transport
+  [{:keys [right-margin ^Transport transport] :as msg}]
+  (reify Transport
+    (recv [this] (.recv transport))
+    (recv [this timeout] (.recv transport timeout))
+    (send [this response]
+      (when (contains? response :value)
+        (pprint-reply msg response))
+      (.send transport (dissoc response :value)))))
+
+(defn wrap-pprint
+  "Middleware that adds a pretty-printing option to the eval op.
+  Passing a non-nil value in the `:pprint` slot will cause eval to call
+  clojure.pprint/pprint on its result. The `:right-margin` slot can be used to
+  bind `*clojure.pprint/*print-right-margin*` during the evaluation."
+  [handler]
+  (fn [{:keys [op pprint] :as msg}]
+    (handler (cond-> msg
+               (and (= op "eval") pprint)
+               (assoc :transport (pprint-transport msg))))))
+
+(set-descriptor!
+ #'wrap-pprint
+  {:requires #{"clone" #'pr-values #'wrap-pprint-fn}
+   :expects #{"eval"}
+   :handles
+   {"pprint-middleware"
+    {:doc "Enhances the `eval` op by adding pretty-printing. Not an op in itself."
+     :optional (merge wrap-pprint-fn-optional-arguments
+                      {"pprint" "If present and non-nil, pretty-print the result of evaluation."})}}})

--- a/src/ipython_clojure/middleware/stacktrace.clj
+++ b/src/ipython_clojure/middleware/stacktrace.clj
@@ -1,0 +1,183 @@
+(ns ipython-clojure.middleware.stacktrace
+  "Cause and stacktrace analysis for exceptions"
+  {:author "Jeff Valk"}
+  (:require [ipython-clojure.middleware.pprint :as pprint]
+            [clojure.repl :as repl]
+            [clojure.string :as str]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.middleware.session :refer [session]]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as t])
+  (:import (clojure.lang Compiler$CompilerException)))
+
+;;; ## Stacktraces
+;;; Modified from cider-nrepl/src/cider/nrepl/middleware/stacktrace.clj
+
+(defn stack-frame
+  "Return a map describing the stack frame."
+  [^StackTraceElement frame]
+  {:name   (str (.getClassName frame) "/" (.getMethodName frame))
+   :file   (.getFileName frame)
+   :line   (.getLineNumber frame)
+   :class  (.getClassName frame)
+   :method (.getMethodName frame)})
+
+(defn analyze-fn
+  "Add namespace, fn, and var to the frame map when the source is a Clojure
+  function."
+  [{:keys [file type class method] :as frame}]
+  (if (= :clj type)
+    (let [[ns fn & anons] (-> (repl/demunge class)
+                              (str/replace #"--\d+" "")
+                              (str/split #"/"))
+          fn (or fn method)] ; protocol functions are not munged
+      (assoc frame
+             :ns  ns
+             :fn  (str/join "/" (cons fn anons))
+             :var (str ns "/" fn)))
+    frame))
+
+(defn analyze-file
+  "Associate the file type (extension) of the source file to the frame map, and
+  add it as a flag. If the name is `NO_SOURCE_FILE`, type `clj` is assumed."
+  [{:keys [file] :as frame}]
+  (let [type (keyword
+              (cond (nil? file)                "unknown"
+                    (= file "NO_SOURCE_FILE")  "clj"
+                    (neg? (.indexOf ^String file ".")) "unknown"
+                    :else (last (.split ^String file "\\."))))]
+    (-> frame
+        (assoc :type type)
+        (update-in [:flags] (comp set conj) type))))
+
+(defn flag-repl
+  "Flag the frame if its source is a REPL eval."
+  [{:keys [file] :as frame}]
+  (if (and file
+           (or (= file "NO_SOURCE_FILE")
+               (.startsWith ^String file "form-init")))
+    (update-in frame [:flags] (comp set conj) :repl)
+    frame))
+
+(defn flag-tooling
+  "Walk the call stack from top to bottom, flagging frames below the first call
+  to `clojure.lang.Compiler` or `clojure.tools.nrepl.*` as `:tooling` to
+  distinguish compilation and nREPL middleware frames from user code."
+  [frames]
+  (let [tool-regex #"^clojure\.lang\.Compiler|^clojure\.tools\.nrepl|^cider\."
+        tool? #(re-find tool-regex (or (:name %) ""))
+        flag  #(if (tool? %)
+                 (update-in % [:flags] (comp set conj) :tooling)
+                 %)]
+    (map flag frames)))
+
+(defn flag-duplicates
+  "Where a parent and child frame represent substantially the same source
+  location, flag the parent as a duplicate."
+  [frames]
+  (cons (first frames)
+        (map (fn [frame child]
+               (if (or (= (:name frame) (:name child))
+                       (and (= (:file frame) (:file child))
+                            (= (:line frame) (:line child))))
+                 (update-in frame [:flags] (comp set conj) :dup)
+                 frame))
+             (rest frames)
+             frames)))
+
+(defn analyze-frame
+  "Return the stacktrace as a sequence of maps, each describing a stack frame."
+  [frame]
+  ((comp flag-repl analyze-fn analyze-file stack-frame) frame))
+
+(defn analyze-stacktrace
+  "Return the stacktrace as a sequence of maps, each describing a stack frame."
+  [^Exception e]
+  (-> (map analyze-frame (.getStackTrace e))
+      (flag-duplicates)
+      (flag-tooling)))
+
+;;; ## Causes
+
+(defn relative-path
+  "If the path is under the project root, return the relative path; otherwise
+  return the original path."
+  [path]
+  (let [dir (str (System/getProperty "user.dir")
+                 (System/getProperty "file.separator"))]
+    (str/replace-first path dir "")))
+
+(defn extract-location
+  "If the cause is a compiler exception, extract the useful location information
+  from its message. Include relative path for simpler reporting."
+  [{:keys [class message] :as cause}]
+  (if (= class "clojure.lang.Compiler$CompilerException")
+    (let [[_ msg file line column]
+          (re-find #"(.*?), compiling:\((.*):(\d+):(\d+)\)" message)]
+      (assoc cause
+             :message msg :file file
+             :path (relative-path file)
+             :line (Integer/parseInt line)
+             :column (Integer/parseInt column)))
+    cause))
+
+;; CLJS REPLs use :repl-env to store huge amounts of analyzer/compiler state
+(def ^:private ex-data-blacklist #{:repl-env})
+
+(defn filtered-ex-data
+  "Same as `ex-data`, but filters out entries whose keys are
+  blacklisted (generally for containing data not intended for reading by a
+  human)."
+  [e]
+  (when-let [data (ex-data e)]
+    (into {} (filter (comp (complement ex-data-blacklist) key) data))))
+
+(defn analyze-cause
+  "Return a map describing the exception cause. If `ex-data` exists, a `:data`
+  key is appended."
+  [^Exception e pprint-fn]
+  (let [m {:class (.getName (class e))
+           :message (.getMessage e)
+           :stacktrace (analyze-stacktrace e)}]
+    (if-let [data (filtered-ex-data e)]
+      (assoc m :data (with-out-str (pprint-fn data)))
+      m)))
+
+(defn analyze-causes
+  "Return the cause chain beginning with the thrown exception, with stack frames
+  for each."
+  [e pprint-fn]
+  (->> e
+       (iterate #(.getCause ^Exception %))
+       (take-while identity)
+       (map (comp extract-location #(analyze-cause % pprint-fn)))))
+
+;;; ## Middleware
+
+(defn wrap-stacktrace-reply
+  [{:keys [session transport pprint-fn] :as msg}]
+  (if-let [e (@session #'*e)]
+    (doseq [cause (analyze-causes e pprint-fn)]
+      (t/send transport (response-for msg cause)))
+    (t/send transport (response-for msg :status :no-error)))
+  (t/send transport (response-for msg :status :done)))
+
+(defn wrap-stacktrace
+  "Middleware that handles stacktrace requests, sending cause and stack frame
+  info for the most recent exception."
+  [handler]
+  (fn [{:keys [op] :as msg}]
+    (if (= "stacktrace" op)
+      (wrap-stacktrace-reply msg)
+      (handler msg))))
+
+;; nREPL middleware descriptor info
+(set-descriptor!
+ #'wrap-stacktrace
+  {:requires #{#'session #'pprint/wrap-pprint-fn} 
+   :expects #{}
+   :handles {"stacktrace"
+             {:doc (str "Return messages describing each cause and stack frame "
+                        "of the most recent exception.")
+              :optional pprint/wrap-pprint-fn-optional-arguments 
+              :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}})

--- a/test/core_test.clj
+++ b/test/core_test.clj
@@ -1,0 +1,63 @@
+(ns ipython-clojure.core-test
+  "Tests nrepl evaluation and error handling."
+  {:author "Peter Denno"}
+  (:require [ipython-clojure.core :refer :all]
+            [clojure.pprint :refer (pprint)]
+            [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [zeromq.zmq :as zmq]
+            [clojure.tools.nrepl :as repl]
+            [clojure.tools.nrepl.server :refer [stop-server]])
+  (:import (clojure.lang Compiler$CompilerException)))
+
+(defn test-start 
+  "Start (e.g. from a CIDER REPL) either an NREPL (:nrepl-only? true) or a full
+  kernel (no args). The latter uses information in resources/connect.json and, e.g.,
+  jupyter-console --existing=$HOME/clojupyter/resources/connect.json --debug"
+  [& {:keys [repl-only? nrepl-only? ]}]
+  (if repl-only?
+    (start-nrepl)
+    (-main (-> "connect.json" io/resource io/file))))
+
+(defn test-stop
+  []
+  (when-let [server @the-nrepl]
+    (stop-server server)
+    (reset! the-nrepl nil)))
+
+(defn test-disconnect 
+  "This can be called from jupyter to disconnect. It attempts to set things back to the way they 
+   would be before -main is called. As of this writing, it won't be pretty but it WILL disconnect."
+  []
+  (test-stop)
+  (let [pargs (-> "connect.json" io/resource io/file list prep-config)
+        hb-addr (address pargs :hb_port)
+        shell-addr (address pargs :shell_port)
+        iopub-addr (address pargs :iopub_port)
+        context (zmq/context 1)]
+    (doto (:hb @jup-sockets)
+      (zmq/unbind hb-addr)
+      (zmq/disconnect hb-addr)
+      (zmq/close))
+    (doto (:sh @jup-sockets)
+      (zmq/unbind shell-addr)
+      (zmq/disconnect shell-addr)
+      (zmq/close))
+    (doto (:io @jup-sockets)
+      (zmq/unbind iopub-addr)
+      (zmq/disconnect iopub-addr)
+      (zmq/close))))
+
+(defn test-send-form 
+  [ & {:keys [form stacktrace clone session ls]}]
+  (with-open [conn (repl/connect :port (:port @the-nrepl))]
+    (doall 
+     (repl/combine-responses        
+      (let [transport (repl/client conn 10000)
+            session (or session @nrepl-session)]
+        (if session
+          (cond form       (repl/message transport {:op "eval" :session session :code form}),
+                ls         (repl/message transport {:op "ls-sessions"}),
+                stacktrace (repl/message transport {:op "stacktrace" :session session}),
+                clone      (repl/message transport {:op :clone}))
+          :no-session))))))


### PR DESCRIPTION
As the subject suggests, this is a major change. Writing a reliable REPL, which is where this code seemed to be heading, is a lot of work. tools.nrepl is a REPL solution made just for this sort of problem, and it is tested (used by emacs/cider etc.) and solid. See the section [why nREPL?](https://github.com/clojure/tools.nrepl) at tools.nrepl github.

I have not experienced any problems changing namespaces in this fork. I implemented stacktraces using code from cider-nrepl. 