### PR TITLE
Changed location of the installation assets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+kernelDir = $(HOME)/.local/share/jupyter/kernels/clojure
+
+ifeq ($(shell uname -s), Linux)
+        kernelDir:=$(HOME)/.local/share/jupyter/kernels/clojure
+endif
+
+ifeq ($(shell uname -s), Darwin)
+        kernelDir:=$(HOME)/Library/Jupyter/kernels/clojure
+endif
+
+
 all:
 	lein uberjar
 	cat bin/clojupyter.template $$(find . -maxdepth 2 -type f | grep -e ".*standalone.*\.jar") > bin/clojupyter
@@ -9,8 +20,9 @@ clean:
 	rm -f bin/clojuypyter
 
 install:
-	mkdir -p ~/.ipython/kernels/clojure
-	cp bin/clojupyter ~/.ipython/kernels/clojure/clojupyter
-	@if [ ! -f ~/.ipython/kernels/clojure/kernel.json ]; then\
-		sed 's|HOME|'${HOME}'|' resources/kernel.json > ~/.ipython/kernels/clojure/kernel.json;\
+	mkdir -p $(kernelDir)
+	cp bin/clojupyter $(kernelDir)/clojupyter
+	@if [ ! -f $(kernelDir)/kernel.json ]; then\
+		sed 's|KERNEL|'${kernelDir}/clojupyter'|' resources/kernel.json > $(kernelDir)/kernel.json;\
 	fi
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Jupyter console and notebook.
 4. make install
 
 This will install a clojupyter executable and a configuration file to tell
-Jupyter how to use it in `~/.ipython/kernels/clojure`.
+Jupyter how to use clojupyter in from jupyter's user kernel location (
+`~/.local/share/jupyter/kernels` on linux and `~/Library/Jupyter/kernels`
+on Mac).
 
 run the REPL with:
 

--- a/resources/kernel.json
+++ b/resources/kernel.json
@@ -1,5 +1,5 @@
 {
- "argv": ["HOME/.ipython/kernels/clojure/clojupyter", "{connection_file}"],
+ "argv": ["KERNEL", "{connection_file}"],
  "display_name": "Clojure",
  "language": "clojure"
 }


### PR DESCRIPTION
Modified location of the install assets to match with the official jupyter documentation
http://jupyter-client.readthedocs.io/en/latest/kernels.html.