### PR TITLE
Cleaned up dependencies and release version 0.1.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 bin/clojupyter
+.idea
+clojupyter.iml

--- a/project.clj
+++ b/project.clj
@@ -1,19 +1,14 @@
-(defproject clojupyter "0.1.0-SNAPSHOT"
+(defproject clojupyter "0.1.0"
   :description "An IPython kernel for executing Clojure code"
   :url "http://github.com/roryk/clojupyter"
   :license {:name "MIT"}
   :dependencies [[beckon "0.1.1"]
                  [cheshire "5.7.0"]
-                 [cider/cider-nrepl "0.15.0-SNAPSHOT"]
+                 [cider/cider-nrepl "0.15.1"]
                  [clj-time "0.11.0"]
                  [com.cemerick/pomegranate "0.3.0"]
                  [com.cemerick/pomegranate "0.3.1"]
                  [com.taoensso/timbre "4.8.0"]
-                 [compliment "0.3.2"]
-                 [fipp "0.6.4"]
-                 [incanter "1.5.7"]
-                 [incanter/jfreechart "1.0.13-no-gnujaxp"]
-                 [mvxcvi/puget "1.0.0"]
                  [net.cgrand/parsley "0.9.3" :exclusions [org.clojure/clojure]]
                  [net.cgrand/sjacket "0.1.1" :exclusions [org.clojure/clojure
                                                           net.cgrand.parsley]]
@@ -24,8 +19,7 @@
                  [org.clojure/tools.nrepl "0.2.12"]
                  [org.zeromq/cljzmq "0.1.4" :exclusions [org.zeromq/jzmq]]
                  [org.zeromq/jeromq "0.3.4"] ; "0.3.5" (modern) fails on zmq/bind.
-                 [pandect "0.5.4"]
-                 [spyscope "0.1.5"]]
+                 [pandect "0.5.4"]]
   :aot [clojupyter.core]
   :main clojupyter.core
   :jvm-opts ["-Xmx250m"]

--- a/src/clojupyter/core.clj
+++ b/src/clojupyter/core.clj
@@ -15,8 +15,7 @@
             [clojure.tools.nrepl.server :as nrepl.server]
             [clojure.walk :as walk]
             [taoensso.timbre :as log]
-            [zeromq.zmq :as zmq]
-            [spyscope.core])
+            [zeromq.zmq :as zmq])
   (:import [java.net ServerSocket])
   (:gen-class :main true))
 

--- a/src/clojupyter/middleware/mime_values.clj
+++ b/src/clojupyter/middleware/mime_values.clj
@@ -1,6 +1,5 @@
 (ns clojupyter.middleware.mime-values
-  (:require [spyscope.core]
-            [clojure.tools.nrepl.transport :as t]
+  (:require [clojure.tools.nrepl.transport :as t]
             [clojupyter.protocol.mime-convertible :as mime]
             [clojure.tools.nrepl.middleware.pr-values])
   (:use [clojure.tools.nrepl.middleware :only (set-descriptor!)])

--- a/src/clojupyter/misc/helper.clj
+++ b/src/clojupyter/misc/helper.clj
@@ -4,7 +4,7 @@
 (defn add-dependencies
   [dependencies & {:keys [repositories]
                    :or {repositories {"central" "http://repo1.maven.org/maven2/"
-                                      "clojars" "http://clojars.org/repo"}}
-                   }]
+                                      "clojars" "http://clojars.org/repo"}}}]
+
   (pg/add-dependencies :coordinates `[~dependencies]
                        :repositories repositories))


### PR DESCRIPTION
I have cleaned up the dependencies and removed the "SNAPSHOT" from the version number.  I would like the package to be published to [clojars](https://clojars.org/) to allow [lein-jupyter](https://github.com/didiercrunch/lein-jupyter) to be self contained and published to clojar itself.

many thanks again for this awesome kernel.  